### PR TITLE
react deploy configmap

### DIFF
--- a/deploy/dev/frontend/configmap.yaml
+++ b/deploy/dev/frontend/configmap.yaml
@@ -4,5 +4,6 @@ metadata:
   name: config-frontend
 data:
   EXAMPLE_ENV_VAR: EXAMPLE_VALUE
-  BACKEND_HOST: chess-backend
-  PORT: "8080"
+    REACT_APP_BACKEND_URL: http://chess-backend
+    REACT_APP_BACKEND_PORT: "8080"
+  


### PR DESCRIPTION
Aim of change:  to set environment variables for the frontend pod by referencing the configmap in the deployment.yaml.
Uses envFrom to achieve this.

configmap.yaml is changed to include the environment variables the react app needs to configure it's endpoints.