### PR TITLE
unskip deploy to dev

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,7 +66,6 @@ jobs:
         cache-to: type=registry,ref=nailien/chess-frontend:buildcache,mode=max
 
   deploy-to-dev:
-    if: github.ref == 'refs/heads/main'
     needs:
     - build-server
     - build-client


### PR DESCRIPTION
main no longer need to be the reference for the runner to start the deploy to dev workflow.